### PR TITLE
Fixing expected payload for encrypted parameters

### DIFF
--- a/docs/POSTBACK_EN.md
+++ b/docs/POSTBACK_EN.md
@@ -56,7 +56,7 @@ Please request for AES key and IV value to your account manager.
 ```json
 {
     "user_id": "testuserid76301", 
-    "action_type": "u", 
+    "click_type": "u", 
     "extra": "{}", 
     "is_media": 0,
     "point": 2,


### PR DESCRIPTION
The example for decrypting the `data` parameter in a postback is incorrect.

After decrypting, the payload is actually:
```json
{
    "user_id": "testuserid76301", 
    "click_type": "u", 
    "extra": "{}", 
    "is_media": 0,
    "point": 2,
    "campaign_id": 3467,
    "event_at": 1442984268,
    "campaign_name": "test campaign",
    "base_point": 2,
    "transaction_id": 429482977
}
```

The difference is:
```diff
-"action_type": "u",
+"click_type": "u",
```

The method I used for decrypting:
```javascript
const crypto = require('crypto');
const decipher = crypto.createDecipheriv('aes-128-cbc', '12341234asdfasdf', '12341234asdfasdf');

const data = Buffer.from('Vblq5XX2g/M2fGs5GRbrLQGh6mwGXDI/frRb2Zn2syY0VAzG6ftcvDzaxSLLvgzYMmvhLTDKZATDX2F9U4AENfBZYQ/Ov+Y9QPfW9A39kaQi/XS3kea09+aI1pO0NkHqP8My8TuR//xhVYtoWovSIw42jbTzUhgJ8SePTC5ZwrLg7bOS7cy3gEgcHL9XzUOrxL8RqMo8fieSMv9hr2YkJJmNL2t0akyj/Hz/lXUvOqhrb9mmFuSlWLF/kS8af3fRKgjxNjGGIVDoVotPipFSbHbpExSp6wY0wsmjfcXGw6g=', 'base64');

let decrypted = decipher.update(payload);
decrypted += decipher.final();

console.log(JSON.parse(decrypted));
```