### PR TITLE
[BS-1181] disable multi window option for CustomLockerActivity

### DIFF
--- a/sample/src/custom/AndroidManifest.xml
+++ b/sample/src/custom/AndroidManifest.xml
@@ -9,7 +9,8 @@
             android:excludeFromRecents="true"
             android:launchMode="singleTask"
             android:screenOrientation="portrait"
-            android:taskAffinity="com.buzzvil.buzzscreen.sample.Locker" />
+            android:taskAffinity="com.buzzvil.buzzscreen.sample.Locker"
+            android:resizeableActivity="false" />
     </application>
 
 </manifest>


### PR DESCRIPTION
- Explicitly set multi window option off for activities
- android:resizeableActivity="false". This option added from Android N (API 24). By default this value is "true"