### PR TITLE
to support android-q

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         applicationId "com.buzzvil.buzzscreen.sample"
@@ -59,7 +59,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-location:16.0.0'
     implementation 'com.android.support:multidex:1.0.1'
 
-    basicImplementation 'com.buzzvil:buzzscreen:2.0.2.0'
-    customImplementation 'com.buzzvil:buzzscreen:2.0.2.0'
-    multiProcessImplementation 'com.buzzvil:buzzscreen-multi-process:2.0.2.0'
+    basicImplementation 'com.buzzvil:buzzscreen:b2.0.4.1'
+    customImplementation 'com.buzzvil:buzzscreen:b2.0.4.1'
+    multiProcessImplementation 'com.buzzvil:buzzscreen-multi-process:b2.0.4.1'
 }


### PR DESCRIPTION
안드로이드 Q 를 지원한다.

diff 와 같이
1. compileSdkVersion 29
2. buzzscreen sdk b2.0.4.1

* android Q 가 현재 beta 버전이기 때문에, 공식적으로 지원하는 buzzscreen-sdk 버전은 추후 확정 예정)